### PR TITLE
Version bumps

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -26,6 +26,8 @@ function create-step() {
   - label: ":docker: :composer: v$minor"
     commands:
       - bash .buildkite/build.sh $version $minor ${composer_versions[$version]}
+    concurrency: 5
+    concurrency_group: "f1/docker"
     plugins:
       - seek-oss/aws-sm#v2.0.0:
           env:

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -10,7 +10,8 @@ shopt -s extglob
 declare -A composer_versions=(
   [1.7.3]=""
   [1.8.6]=""
-  [1.9.1]="1 latest"
+  [1.9.3]=""
+  [1.10.4]="1 latest"
 )
 
 # Usage: create-step <version>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Images built from this repository are simply the Docker Hub's [`library/composer
 
 Currently, we build the following versions of Composer:
 
-- `1.9`, `1`, `latest`
+- `1.10`, `1`, `latest`
+- `1.9`
 - `1.8`
 - `1.7`
 


### PR DESCRIPTION
This PR bumps our version of composer 1.9 to the latest and adds support for 1.10. In addition, it uses the standard concurrency groups we use for other Docker builds.