### PR TITLE
Refactor to build multiple images on 7.4

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -8,19 +8,16 @@ set -euo pipefail
 
 repository=forumone/composer
 
-# Save the version specially (we need it as a build arg)
-version="$1"
-shift
+# Save the minor version specifically (we need it to target the Dockerfile)
+version="$2"
 
 # Capture the version and any other tags as --tag arguments for docker build
-tag_args=("--tag" "$repository:$version")
 for tag in "$@"; do
   tag_args+=("--tag" "$repository:$tag")
 done
 
 echo '--- :docker: Build'
-docker build . \
-  --build-arg "COMPOSER_VERSION=$version" \
+docker build  "./${version}" \
   "${tag_args[@]}"
 
 if test "$BUILDKITE_BRANCH" == master && test "$BUILDKITE_PULL_REQUEST" == false; then

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -8,10 +8,8 @@ shopt -s extglob
 # the sole exception of minor versions, since those can be auto-generated safely. This
 # versioning scheme matches what's on the Docker Hub.
 declare -A composer_versions=(
-  [1.7.3]=""
-  [1.8.6]=""
-  [1.9.3]=""
-  [1.10.4]="1 latest"
+  [1.10.22]="1"
+  [2.0.14]="2 latest"
 )
 
 # Usage: create-step <version>

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Track updates for the 1.10 Composer release
+  - package-ecosystem: "docker"
+    directory: "1.10/"
+    schedule:
+      intervale: "weekly"
+
+  # Track updates for the 2.0 Composer release
+  - package-ecosystem: "docker"
+    directory: "2.0/"
+    schedule:
+      intervale: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,10 @@ updates:
   - package-ecosystem: "docker"
     directory: "1.10/"
     schedule:
-      intervale: "weekly"
+      interval: "weekly"
 
   # Track updates for the 2.0 Composer release
   - package-ecosystem: "docker"
     directory: "2.0/"
     schedule:
-      intervale: "weekly"
+      interval: "weekly"

--- a/1.10/Dockerfile
+++ b/1.10/Dockerfile
@@ -25,7 +25,7 @@ RUN printf "# composer php cli ini settings\n\
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
-ENV COMPOSER_VERSION 2.0.13
+ENV COMPOSER_VERSION 1.10.22
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 

--- a/1.10/Dockerfile
+++ b/1.10/Dockerfile
@@ -1,0 +1,41 @@
+FROM composer:1.10.22 AS composer
+
+FROM php:7.4.10-cli-alpine
+
+# Dependencies copied from the community composer image.
+# See https://github.com/composer/docker/blob/master/1.10/Dockerfile.
+RUN set -eux; \
+  apk add --no-cache --virtual .composer-rundeps \
+  bash \
+  coreutils \
+  git \
+  make \
+  mercurial \
+  openssh-client \
+  patch \
+  subversion \
+  tini \
+  unzip \
+  zip
+
+RUN printf "# composer php cli ini settings\n\
+  date.timezone=UTC\n\
+  memory_limit=-1\n\
+  " > $PHP_INI_DIR/php-cli.ini
+
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_HOME /tmp
+ENV COMPOSER_VERSION 2.0.13
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+# Install the prestissimo plugin to speed operations on Composer 1.
+RUN composer global require hirak/prestissimo
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+WORKDIR /app
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["composer"]

--- a/1.10/docker-entrypoint.sh
+++ b/1.10/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+isCommand() {
+  # Retain backwards compatibility with common CI providers,
+  # see: https://github.com/composer/docker/issues/107
+  if [ "$1" = "sh" ]; then
+    return 1
+  fi
+
+  composer help "$1" > /dev/null 2>&1
+}
+
+# check if the first argument passed in looks like a flag
+if [ "${1#-}" != "$1" ]; then
+  set -- /sbin/tini -- composer "$@"
+# check if the first argument passed in is composer
+elif [ "$1" = 'composer' ]; then
+  set -- /sbin/tini -- "$@"
+# check if the first argument passed in matches a known command
+elif isCommand "$1"; then
+  set -- /sbin/tini -- composer "$@"
+fi
+
+exec "$@"

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -1,0 +1,38 @@
+FROM composer:2.0.13 AS composer
+
+FROM php:7.4.10-cli-alpine
+
+# Dependencies copied from the community composer image.
+# See https://github.com/composer/docker/blob/master/1.10/Dockerfile.
+RUN set -eux; \
+  apk add --no-cache --virtual .composer-rundeps \
+  bash \
+  coreutils \
+  git \
+  make \
+  mercurial \
+  openssh-client \
+  patch \
+  subversion \
+  tini \
+  unzip \
+  zip
+
+RUN printf "# composer php cli ini settings\n\
+  date.timezone=UTC\n\
+  memory_limit=-1\n\
+  " > $PHP_INI_DIR/php-cli.ini
+
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_HOME /tmp
+ENV COMPOSER_VERSION 2.0.13
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+WORKDIR /app
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["composer"]

--- a/2.0/docker-entrypoint.sh
+++ b/2.0/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+isCommand() {
+  # Retain backwards compatibility with common CI providers,
+  # see: https://github.com/composer/docker/issues/107
+  if [ "$1" = "sh" ]; then
+    return 1
+  fi
+
+  composer help "$1" > /dev/null 2>&1
+}
+
+# check if the first argument passed in looks like a flag
+if [ "${1#-}" != "$1" ]; then
+  set -- /sbin/tini -- composer "$@"
+# check if the first argument passed in is composer
+elif [ "$1" = 'composer' ]; then
+  set -- /sbin/tini -- "$@"
+# check if the first argument passed in matches a known command
+elif isCommand "$1"; then
+  set -- /sbin/tini -- composer "$@"
+fi
+
+exec "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-ARG COMPOSER_VERSION
-FROM composer:${COMPOSER_VERSION}
-
-RUN composer global require hirak/prestissimo

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # About this Image
 
-Images built from this repository are simply the Docker Hub's [`library/composer`](https://hub.docker.com/_/composer) image, but with [hirak/prestissimo](https://packagist.org/packages/hirak/prestissimo) pre-installed globally.
+Images built from this repository are parallel implementations of the Docker Hub's [`library/composer`](https://hub.docker.com/_/composer) image,
+but they are built on top of PHP 7.4 to sidestep dependency resolution issues with the community image being built on PHP 8.
+
+Images with Composer `1.10` are built with [hirak/prestissimo](https://packagist.org/packages/hirak/prestissimo) pre-installed globally.
 
 ## Composer Versions and Tags
 
 Currently, we build the following versions of Composer:
 
-- `1.10`, `1`, `latest`
-- `1.9`
-- `1.8`
-- `1.7`
+- `2.0`, `2`, `latest`
+- `1.10`, `1`
 
 ## License
 


### PR DESCRIPTION
Refactor the repo into a monorepo structure to support building multiple Composer version images on top of PHP 7.4.

This deviates the project from its original purpose of extending the community Composer image and adding Prestissimo. Instead, this project now builds a parallel solution on PHP 7.4 instead of PHP 8 which is used in those images.