### PR TITLE
Updating to have a 2 version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,6 +14,7 @@ definitions:
       composer_version:
         - "1.10"
         - "2.2"
+        - "2"
         - "2.3"
   docker-build: &docker-build
     - "docker build -t $DOCKER_HUB_REPO:{{matrix.composer_version}}-php-{{matrix.php}} --build-arg PHP_VERSION={{matrix.php}} --build-arg COMPOSER_VERSION={{matrix.composer_version}} ."

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ with Composer version `1.10` is built with [hirak/prestissimo](https://packagist
 Currently, we build the following versions of `Composer` & `PHP`:
 
 - `2.2-php-7.4`
+- `2-php-7.4`
 - `2.2-php-8.0`
 - `2.3-php-7.4`
 - `2.3-php-8.0`
+- `2-php-8.0`
 - `1.10-php-7.4`
 - `1.10-php-8.0`
 


### PR DESCRIPTION
Things that have changed:
* [x] Added a more generic number for composer `2-php-8.0` & `2-php-7.4`