### PR TITLE
fix(README): Updates the README to call our Composer 2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ Images built from this repository are parallel implementations of the Docker Hub
 ## Versions and Tags
 
 * Supported PHP versions: 8.3, 8.2, 8.1, 8.0
-* Supported Composer versions: 2.7, 2.6, 2.5, 2.4, 2.3, 2.2
+* Supported Composer versions: 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2
 
-Tags are constructed using `${COMPOSER_VERSION}-php-${PHP_VERSION}`. For example, Composer 2.7 running on PHP 8.3 is `2.7-php-8.3`.
+Tags are constructed using `${COMPOSER_VERSION}-php-${PHP_VERSION}`. For example, Composer 2.8 running on PHP 8.3 is `2.8-php-8.3`.
+
+The `2-` tag will generally always represent the latest 2.x version of Composer.
 
 ## License
 


### PR DESCRIPTION
- Updates the README to include support for Composer 2.8.
- Updates the README to clarify that the `2-` tags will always point to the latest 2.x release of Composer.
