### PR TITLE
fix: Changes Docker image dependency and target PHP versions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,6 @@ definitions:
   matrix: &matrix
     setup:
       php:
-        - "8.0"
         - "8.1"
         - "8.2"
         - "8.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
+06/02/2025
+---------
+- Changes the base PHP image to be the Forum One php-cli image.
+  - Updates the image to no use `bookworm` instead of `bullseye`.
+  - Updates to provide additional PHP extensions required for some Composer package installation.
+- Updates the `Dockerfile` to reduce build times and image sizes.
+- Drops on-going support for PHP 8.0.
+
 05/06/2024
+----------
 - Updated Docker image to convert from alpine to debian
 
 03/19/2024
+----------
 - Added composer 2.7
 - Added php 8.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,27 +3,22 @@ ARG PHP_VERSION
 
 FROM composer:${COMPOSER_VERSION} AS composer
 
-FROM php:${PHP_VERSION}-cli-bullseye
-
-COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
-
-RUN apt update;
+FROM public.ecr.aws/forumone/php-cli:${PHP_VERSION}
 
 # Dependencies copied from the community composer image.
 # See https://github.com/composer/docker/blob/master/1.10/Dockerfile.
-RUN set -eux; \
-  apt install -y \
-  coreutils \
-  git \
-  make \
-  openssh-client \
-  patch \
-  tini \
-  unzip \
-  zip
-
-# installing php extention needing for craftCMS
-RUN install-php-extensions zip
+RUN set -eux \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    coreutils \
+    git \
+    make \
+    openssh-client \
+    patch \
+    tini \
+    unzip \
+    zip \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN printf "# composer php cli ini settings\n\
   date.timezone=UTC\n\

--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 Images built from this repository are parallel implementations of the Docker Hub's [`library/composer`](https://hub.docker.com/_/composer) image.
 
+These images include a small utility, `install-php-extensions`, to simplify the task of installing common extensions. For example, to install SOAP, one only needs to add this to their Dockerfile:
+```sh
+# Install the core SOAP extension
+RUN install-php-extensions soap
+````
+
 ## Versions and Tags
 
-* Supported PHP versions: 8.3, 8.2, 8.1, 8.0
+* Supported PHP versions: 8.3, 8.2, 8.1
 * Supported Composer versions: 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2
 
 Tags are constructed using `${COMPOSER_VERSION}-php-${PHP_VERSION}`. For example, Composer 2.8 running on PHP 8.3 is `2.8-php-8.3`.


### PR DESCRIPTION
- Changes the base PHP image to be the Forum One php-cli image.
  - Updates the image to no use `bookworm` instead of `bullseye`.
  - Updates to provide additional PHP extensions required for some Composer package installation.
- Updates the `Dockerfile` to reduce build times and image sizes.
- Drops on-going support for PHP 8.0.
