### PR TITLE
feat(Composer/PHP): Updates Composer & PHP Version Support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,8 @@ definitions:
         - "8.1"
         - "8.2"
         - "8.3"
+        - "8.4"
+        - "8.5"
       composer:
         - "2"
         - "2.2"
@@ -22,6 +24,7 @@ definitions:
         - "2.6"
         - "2.7"
         - "2.8"
+        - "2.9"
 
   agents-amd64: &agents-amd64
     queue: docker-builders

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ RUN install-php-extensions soap
 
 ## Versions and Tags
 
-* Supported PHP versions: 8.3, 8.2, 8.1
-* Supported Composer versions: 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2
+* Supported PHP versions: 8.5, 8.4, 8.3, 8.2, 8.1
+* Supported Composer versions: 2(latest-2.x), 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2
 
 Tags are constructed using `${COMPOSER_VERSION}-php-${PHP_VERSION}`. For example, Composer 2.8 running on PHP 8.3 is `2.8-php-8.3`.
 


### PR DESCRIPTION
- Adds support for PHP 8.4 & 8.5.
- Adds tagged version support for Composer 2.9.
- Updates README to include supported versions.
